### PR TITLE
Use containers >=0.5

### DIFF
--- a/tasty-fail-fast.cabal
+++ b/tasty-fail-fast.cabal
@@ -36,7 +36,7 @@ library
   build-depends:       base < 5
                      , tasty >= 0.10 && < 0.12
                      , stm >= 2.1
-                     , containers >= 0.1.0.0
+                     , containers >= 0.5.0.0
                      , tagged
   default-language:    Haskell2010
 


### PR DESCRIPTION
fixes:

> Could not find module `Data.IntMap.Strict'
